### PR TITLE
add datadog logging example

### DIFF
--- a/templates/javascript/datadog_logging.js
+++ b/templates/javascript/datadog_logging.js
@@ -1,0 +1,22 @@
+const handleRequest = evt => {
+  // Using waitUntil confirms that the log request finished before
+  // the Workers script stops executing
+  evt.waitUntil(log('Received request: ', evt.request.url))
+  return fetch(evt.request)
+}
+
+// Identifies the logging client in Datadog's UI. 
+// Can be hard-coded to something like "edge", or can be
+// customized per environment using `wrangler secret put SERVICE_NAME`
+const SERVICE_NAME = "edge"
+
+const log = body => 
+  // DATADOG_API_KEY is an API key generated in Datadog's UI
+  fetch(`https://http-intake.logs.datadoghq.com/v1/input/${DATADOG_API_KEY}`, {
+    method: 'POST',
+    body: JSON.stringify(Object.assign({}, body, { service: SERVICE_NAME })),
+    headers: { 'Content-type': 'application/json' },
+  })
+
+
+addEventListener('fetch', handleRequest)

--- a/templates/javascript/datadog_logging.js
+++ b/templates/javascript/datadog_logging.js
@@ -2,7 +2,7 @@ const handleRequest = evt => {
   // Using waitUntil confirms that the log request finished before
   // the Workers script stops executing
   evt.waitUntil(log('Received request: ', evt.request.url))
-  return fetch(evt.request)
+  evt.respondWith(fetch(evt.request))
 }
 
 // Identifies the logging client in Datadog's UI. 

--- a/templates/meta_data/datadog_logging.toml
+++ b/templates/meta_data/datadog_logging.toml
@@ -1,0 +1,6 @@
+id = "datadog_logging"
+weight = 1
+type = "snippet"
+title = "Datadog Logging Integratoin"
+description = "Log from your Workers application to Datadog's logging service"
+share_url = "/templates/snippets/datadog_logging"


### PR DESCRIPTION
this pull request adds a snippet for showing how to log from a workers application to datadog, a logging provider. i haven't submitted a template in a while so let me know if is formatted wrong!