### PR TITLE
Use unescape instead of searchParams

### DIFF
--- a/templates/javascript/cors_header_proxy.js
+++ b/templates/javascript/cors_header_proxy.js
@@ -1,6 +1,6 @@
 async function handleRequest(request) {
   const url = new URL(request.url)
-  const apiurl = url.searchParams.get('apiurl')
+  const apiurl = unescape(unescape(url.search.substr(8)));
   // Rewrite request to point to API url. This also makes the request mutable
   // so we can add the correct Origin header to make the API server think
   // that this request isn't cross-site.


### PR DESCRIPTION
-Fix apiurl with query string getting stripped
Referred for code : https://github.com/Zibri/cloudflare-cors-anywhere/blob/2f5bae4c00bac89018e2ae7edc860ecba2a2223b/index.js#L48