### PR TITLE
Updates CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,44 @@
 # Contributing Cloudflare Workers Templates
+
 - [Template Metadata](#template-metadata)
-  * [Required Properties](#required-properties)
-  * [Optional Properties](#optional-properties)
+  - [Required Properties](#required-properties)
+  - [Optional Properties](#optional-properties)
 - [Template Content](#template-content)
-  * [Snippet Content](#snippet-content)
-  * [Boilerplate Template Content](#boilerplate-template-content)
+  - [Snippet Content](#snippet-content)
+  - [Boilerplate Template Content](#boilerplate-template-content)
 - [Updating a Template](#updating-a-template)
 - [Creating a Snippet](#creating-a-snippet)
 - [Creating a Boilerplate](#creating-a-boilerplate)
-  * [Testing Your Boilerplate](#testing-your-boilerplate)
-  * [Submitting a Boilerplate to the Template Registry](#submitting-a-boilerplate-to-the-template-registry)
+  - [Testing Your Boilerplate](#testing-your-boilerplate)
+  - [Submitting a Boilerplate to the Template Registry](#submitting-a-boilerplate-to-the-template-registry)
 
 This repository supplies the list of templates that appear in the [Template Gallery on the Cloudflare Workers documentation website](https://developers.cloudflare.com/workers/templates/).
 
 There are two types of templates:
-* *Snippet*: A simple template whose content lives in a single TypeScript file in this repository in the `templates/typescript` directory. A snippet’s code will be displayed inline in the Template Gallery. Snippets are short and intended for users to copy-and-paste into their own projects, or use as a reference.
-* *Boilerplate*: A more-complex template whose content lives in a separate repository, may consist of multiple files, and can be used to generate a new project by invoking `wrangler generate path-to-template-repository`. Their content is not displayed directly in the Workers documentation; rather, each boilerplate includes a link to the source repository and a `wrangler generate` command to create a project from the boilerplate. They often have more detailed documentation, either in the template repository’s `README`, or in an article in the Workers docs [like this one](https://github.com/cloudflare/workers-docs/blob/master/workers-docs/src/content/templates/pages/graphql_server.md).
+
+- *Snippet*: A simple template whose content lives in a single TypeScript file in this repository in the `templates/typescript` directory. A snippet’s code will be displayed inline in the Template Gallery. Snippets are short and intended for users to copy-and-paste into their own projects, or use as a reference.
+- *Boilerplate*: A more-complex template whose content lives in a separate repository, may consist of multiple files, and can be used to generate a new project by invoking `wrangler generate path-to-template-repository`. Their content is not displayed directly in the Workers documentation; rather, each boilerplate includes a link to the source repository and a `wrangler generate` command to create a project from the boilerplate. They often have more detailed documentation, either in the template repository’s `README`, or in an article in the Workers docs [like this one](https://github.com/cloudflare/workers-docs/blob/master/workers-docs/src/content/templates/pages/graphql_server.md).
 
 ## Template Metadata
-Each template is defined by a `toml` file in the [`templates/meta_data`](./templates/meta_data) directory.
 
-https://github.com/cloudflare/template-registry/blob/f2a21ff87a4f9c60ce1d426e9e8d2e6807b786fd/templates/meta_data/hello_world.toml#L1-L11
+Each template is defined by a `toml` file in the [`templates/meta_data`](./templates/meta_data) directory. For example, this is the contents of [`hello_world.toml`](https://github.com/cloudflare/template-registry/blob/f2a21ff87a4f9c60ce1d426e9e8d2e6807b786fd/templates/meta_data/hello_world.toml#L1-L11):
+
+```toml
+id = "hello_world"
+weight = 99
+type = "boilerplate"
+title = "Hello World"
+description = "Simple Hello World in JS"
+repository_url = "https://github.com/cloudflare/worker-template"
+
+[demos.main]
+text = "Demo"
+url = "https://cloudflareworkers.com/#6626eb50f7b53c2d42b79d1082b9bd37:https://tutorial.cloudflareworkers.com"
+tags = [ "Originless" ]
+```
 
 ### Required Properties
+
 ```yaml
 id = "some_unique_alphanumeric_slug"
 title =  "Title of your template"
@@ -30,11 +46,13 @@ description = "Concise 1-2 sentences that explains what your template does"
 ```
 
 Boilerplate templates must also have a `repository_url` property that links to the repository where the template code lives:
+
 ```yaml
 repository_url = "https://github.com/<you>/<id>"
 ```
 
 ### Optional Properties
+
 ```yaml
 share_url="/templates/pages/id " #path to another resource, like a tutorial, that will be displayed alongside the template
 tags = ["TypeScript", "Enterprise"] # arbitrary tags that can be used to filter templates in the Template Gallery
@@ -45,14 +63,17 @@ url = "https://cloudflareworkers.com/#6cbbd3ae7d4e928da3502cb9ce11227a:https://t
 ```
 
 ## Template Content
+
 Templates should follow our [JavaScript/TypeScript style guide](./style/javascript.md).
 
 ### Snippet Content
+
 Snippet template content lives in [`templates/typescript`](./templates/typescript). TypeScript snippet definitions are also transpiled to JavaScript, and the JavaScript versions are committed to source control in [`templates/javascript`](./templates/javascript).
 
 A snippet with an `id` of `example` is expected to have a TypeScript content definition named `example.ts` and a JavaScript content definition named `example.js`.
 
 Snippets should consist of the following components, in this specific order:
+
 1. A `handleRequest` function definition
 2. A call to `addEventListener`
 3. Helper functions
@@ -79,9 +100,11 @@ addEventListener('fetch', event => {
 Snippets *should not* contain any blank lines. This makes them easier to present in a small amount of space in the Template Gallery.
 
 ### Boilerplate Template Content
+
 Boilerplate template content lives in another repository; only metadata about these templates lives in this repository. The metadata allows the Workers Docs to render information about these templates.
 
 Boilerplate templates can be used to start a new project by running:
+
 ```bash
 wrangler generate https://github.com/path/to/template
 ```
@@ -93,6 +116,7 @@ Refer to the [documentation of `cargo-generate`](https://github.com/ashleygwilli
 Boilerplate templates should not contain any generated artifacts, like the `worker` directory of a default `wrangler` project.
 
 Example boilerplate templates include:
+
 * [cloudflare/worker-template](https://github.com/cloudflare/worker-template)
 * [EverlastingBugstopper/worker-typescript-template](https://github.com/EverlastingBugstopper/worker-typescript-template)
 * [signalnerve/workers-graphql-server](https://github.com/signalnerve/workers-graphql-server)
@@ -102,20 +126,24 @@ Example boilerplate templates include:
 
 You can write additional documentation about your template that will be displayed in the Workers documentation, like this:
 
-[Template Gallery | Hello World Rust ](https://developers.cloudflare.com/workers/templates/pages/hello_world_rust)
+[Template Gallery | Hello World Rust](https://developers.cloudflare.com/workers/templates/pages/hello_world_rust)
 
 Such additional documentation lives in the [cloudflare/workers-docs](https://github.com/cloudflare/workers-docs/) repository.
 
 ## Updating a Template
+
 If you spot an error in a template, feel free to make a PR against this repository!
 
 If you want to update the contents of a snippet, edit the TypeScript file (not the transpiled JavaScript version), and then run:
+
 ```bash
 npm run transpile && npm run lint
 ```
+
 This will transpile your TypeScript changes to the JavaScript version as well.
 
 ## Creating a Snippet
+
 1. Clone this repository.
 2. Run `npm install` from the repo’s root directory to install development dependencies.
 3. Choose an `id` for your template. This should be a unique and descriptive “slug” like the other filenames in [`templates/meta_data`](./templates/meta_data).
@@ -124,31 +152,36 @@ This will transpile your TypeScript changes to the JavaScript version as well.
 6. Run `npm run transpile && npm run lint` to generate the JavaScript version of your TypeScript file.
 7. Test your snippet in the [Cloudflare Workers Playground](https://cloudflareworkers.com/) or in a `wrangler` project.
 8. Make a PR to this repository containing three files:
-	* `templates/meta_data/your_template_id.toml`
-	* `templates/typescript/your_template_id.ts`
-	* `templates/javascript/your_template_id.js`
+   - `templates/meta_data/your_template_id.toml`
+   - `templates/typescript/your_template_id.ts`
+   - `templates/javascript/your_template_id.js`
 
 ## Creating a Boilerplate
+
 You can get started by cloning the [template creator](https://github.com/victoriabernard92/workers-template-creator) and following the instructions in the README. You can also start from scratch and add template placeholders to any `wrangler` project.
 
 ### Testing Your Boilerplate
+
 A boilerplate must be capable of being installed with `wrangler generate`.
 
 Test using [`wrangler`](https://github.com/cloudflare/wrangler) to generate a new project from your boilerplate template:
-```
+
+```bash
 wrangler generate your-template-id ./
 cd your-template-slug
 wrangler preview --watch
 ```
 
 Finally, publish your template in a public GitHub repo, and then test your boilerplate template by running:
-```
+
+```bash
 wrangler generate https://github.com/<you>/<your-template-id>
 cd your-template-id
 wrangler preview --watch
 ```
 
 ### Submitting a Boilerplate to the Template Registry
+
 Create a metadata file for your template in `templates/meta_data`. Make sure to include a `repo` link to your boilerplate template’s GitHub repository.
 
 Then make a PR to this repo with your new metadata `toml` file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,199 +1,154 @@
-- [Introduction](#introduction)
-    + [What makes a Good Template](#what-makes-a-good-template)
-    + [ID your Template](#id-your-template)
-- [Snippets versus Boilerplates](#snippets-versus-boilerplates)
-- [Building a Template](#building-a-template)
-    + [Create a Snippet](#create-a-snippet)
-    + [Create a Boilerplate](#create-a-boilerplate)
-- [Writing Templates](#writing-templates)
-    + [Boilerplate Format](#boilerplate-format)
-    + [Snippet Format](#snippet-format)
-  * [Style](#style)
-    + [JavaScript Styleguide](#javascript-styleguide)
-    + [Rust Styleguide](#rust-styleguide)
-- [`id.toml`](#-idtoml-)
-    + [Mandatory Fields for All](#mandatory-fields-for-all)
-    + [Optional Fields](#optional-fields)
-- [Summit](#summit)
-    + [**Required:**](#required)
-    + [Boilerplate Only](#boilerplate-only)
+# Contributing Cloudflare Workers Templates
+- [Template Metadata](#template-metadata)
+  * [Required Properties](#required-properties)
+  * [Optional Properties](#optional-properties)
+- [Template Content](#template-content)
+  * [Snippet Content](#snippet-content)
+  * [Boilerplate Template Content](#boilerplate-template-content)
+- [Updating a Template](#updating-a-template)
+- [Creating a Snippet](#creating-a-snippet)
+- [Creating a Boilerplate](#creating-a-boilerplate)
+  * [Testing Your Boilerplate](#testing-your-boilerplate)
+  * [Submitting a Boilerplate to the Template Registry](#submitting-a-boilerplate-to-the-template-registry)
 
+This repository supplies the list of templates that appear in the [Template Gallery on the Cloudflare Workers documentation website](https://developers.cloudflare.com/workers/templates/).
 
-# Introduction
+There are two types of templates:
+* *Snippet*: A simple template whose content lives in a single TypeScript file in this repository in the `templates/typescript` directory. A snippet’s code will be displayed inline in the Template Gallery. Snippets are short and intended for users to copy-and-paste into their own projects, or use as a reference.
+* *Boilerplate*: A more-complex template whose content lives in a separate repository, may consist of multiple files, and can be used to generate a new project by invoking `wrangler generate path-to-template-repository`. Their content is not displayed directly in the Workers documentation; rather, each boilerplate includes a link to the source repository and a `wrangler generate` command to create a project from the boilerplate. They often have more detailed documentation, either in the template repository’s `README`, or in an article in the Workers docs [like this one](https://github.com/cloudflare/workers-docs/blob/master/workers-docs/src/content/templates/pages/graphql_server.md).
 
-### What makes a Good Template
+## Template Metadata
+Each template is defined by a `toml` file in the [`templates/meta_data`](./templates/meta_data) directory.
 
-The goal of any template is to be reusable amongst several projects, developers and entities; therefore, any template must be able to be used in a generic form. That does not mean that you can't use things like hardcoded constants, it just means those constants must be obvious and the logic must be generic.
+https://github.com/cloudflare/template-registry/blob/f2a21ff87a4f9c60ce1d426e9e8d2e6807b786fd/templates/meta_data/hello_world.toml#L1-L11
 
-Custom solutions that would could not clearly be reused make bad templates.
-
-### ID your Template
-
-Your template should have a programmatically ID (I will refer to as `id`) and human readable description:
-
-Examples:
-
-- Generic template for cloud storage with an arbitrary cloud provider - `cloud_storage`
-- Authentication with pre-shared header key - `auth_key_header`
-
-You'll want to make sure your ID does not conflict with existing snippet names.
-
-# Snippets versus Boilerplates
-
-Template is an umbral term for both snippets and boilerplate. Our gallery uses both. Before building a template distinguish it as a template or a boilerplate. We define them as:
-
-**boilerplate**: a reusable project likely containing _more than one file_ that can serve as a skeleton code for those beginning a project
-
-Boilerplates will be displayed in the template gallery as `wrangler generate` commands
-
-Examples (will add links):
-
-- Rust Wasm
-- Image Compression
-- Create React App
-- GraphQL
-
-**snippet**: copy-pastable code for either those beginning a project or adding into a project. Meant to not depend on multiple files.
-
-Snippets will be displayed by default in the template gallery as the code collapsed.
-
-Examples (will add links):
-
-- Modify header
-- Bulk redirects
-
-**both(rare)**: a simple project that consists of a single file that one would use as a boilerplate for building out a project but could also easily copy-paste (e.g. hello-world). In this case, you can build out either or both.
-
-# Building a Template
-
-### Create a Snippet
-
-If you are just designing a snippet, you can skip the setup and move to writing template.
-
-### Create a Boilerplate
-
-First clone the [template creator](https://github.com/victoriabernard92/workers-template-creator) and follow the instructions in the README to get your project started.
-
-Never commit the `worker` directory. Commit your `wrangler.toml`and `workers-site` directory (if applicable) with the required `type`, but don't commit the account tags.
-
-# Writing Templates
-
-### Boilerplate Format
-
-A boilerplate will always be a project of multiple files that can run with the `wrangler generate`
-
-You must test using [wrangler](https://github.com/cloudflare/wrangler) to generate a new project against your repo.
-
-```
-wrangler generate myTempName ./
-cd myTempName
-wrangler preview --watch
+### Required Properties
+```yaml
+id = "some_unique_alphanumeric_slug"
+title =  "Title of your template"
+description = "Concise 1-2 sentences that explains what your template does"
 ```
 
-You do not need to strictly follow the snippet format for boilerplates, but it is recommended.
+Boilerplate templates must also have a `repository_url` property that links to the repository where the template code lives:
+```yaml
+repository_url = "https://github.com/<you>/<id>"
+```
 
-### Snippet Format
+### Optional Properties
+```yaml
+share_url="/templates/pages/id " #path to another resource, like a tutorial, that will be displayed alongside the template
+tags = ["TypeScript", "Enterprise"] # arbitrary tags that can be used to filter templates in the Template Gallery
 
-Test your snippet code with the playground and live on a domain. All snippet code must work unminified in the playground and be tested live.
+[demos.main]
+title = "Demo"
+url = "https://cloudflareworkers.com/#6cbbd3ae7d4e928da3502cb9ce11227a:https://tutorial.cloudflareworkers.com/foo" # a live demo of your code
+```
 
-The format of a snippet should be in the order:
+## Template Content
+Templates should follow our [JavaScript/TypeScript style guide](./style/javascript.md).
 
-1. `handleRequest`
-2. `addEventListener('fetch', event => {`
+### Snippet Content
+Snippet template content lives in [`templates/typescript`](./templates/typescript). TypeScript snippet definitions are also transpiled to JavaScript, and the JavaScript versions are committed to source control in [`templates/javascript`](./templates/javascript).
+
+A snippet with an `id` of `example` is expected to have a TypeScript content definition named `example.ts` and a JavaScript content definition named `example.js`.
+
+Snippets should consist of the following components, in this specific order:
+1. A `handleRequest` function definition
+2. A call to `addEventListener`
 3. Helper functions
-4. Hardcoded constants, the developer will likely change
+4. Hardcoded constants which a user will likely change
 
-For example:
+Most of the logic should be in a function called `handleRequest`, which should have one of the following type signatures:
 
-```javascript
-async function handleRequest(request) {
-  helper(request.url.path)
-  return new Response('Hello worker!', { status: 200 })
-}
-addEventListener('fetch', event => {
-  event.respondWith(handleRequest(event.request))
-})
-/**
- * Here is what my helper does
- * @param {string} path
- */
-function helper(path) {
-  return url + '/' + path
-}
-/**
- * Here are what developers are expected to fill in
- * Replace URL with the host you wish to send requests to
- * @param {string} URL
- */
-const URL = 'https://example.com'
-```
-
-For snippets, the meat of the logic should be in a function called `handleRequest`, which should always exist in either forms:
-
-```javascript
+```typescript
 function handleRequest(request: Request): Promise<Response>
 function handleRequest(request: Request): Response
 ```
 
-The event listener should almost most always be exactly:
+The event listener should be one of the following:
 
-```javascript
+```typescript
 addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request))
 })
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest())
+})
 ```
 
-Omit all blank links in your snippet for formatting purposes (i.e. A regex find should have 0 results for `\n\n`.)
+Snippets *should not* contain any blank lines. This makes them easier to present in a small amount of space in the Template Gallery.
 
-For an example see [Modify Request URL](/templates/javascript). 
+### Boilerplate Template Content
+Boilerplate template content lives in another repository; only metadata about these templates lives in this repository. The metadata allows the Workers Docs to render information about these templates.
 
-## Style
-
-### JavaScript Styleguide
-
-Required, see guide [here](./style/javascript.md)
-
-### Rust Styleguide
-
-Required if writing Rust, see guide [here](./style/rust.md)
-
-# `id.toml`
-
-Once you've written the template you'd like to share, its time to configure your id.toml.  Templates have the following options:
-
-### Mandatory Fields for All
-```id.toml
-id = "id"
-title =  "Title of your template"
-description = "Concise 1-2 sentences that explains what your template does"
-share_url="/templates/pages/id " #path to in depth tutorial of your code
-repository_url = "https://github.com/<you>/<id>" #boilerplate only required
+Boilerplate templates can be used to start a new project by running:
+```bash
+wrangler generate https://github.com/path/to/template
 ```
 
-### Optional Fields
-```id.toml
-tags = ["Originless", "Enterprise"] # first letter must be caps
+`wrangler` clones the repo containing the boilerplate template and performs some simple templating logic using [`cargo-generate`](https://github.com/ashleygwilliams/cargo-generate).
 
-[demos.main] 
-title = "Title"
-url = "" # a live demo of your code (can be an array)
+Refer to the [documentation of `cargo-generate`](https://github.com/ashleygwilliams/cargo-generate/blob/master/README.md) for information about template placeholders like `{{ project-name }}` and `{{ authors }}`, as well as the use of a `.genignore` file or the `exclude` and `include` directives to determine which files from the template repository should end up in the user’s generated project directory.
+
+Boilerplate templates should not contain any generated artifacts, like the `worker` directory of a default `wrangler` project.
+
+Example boilerplate templates include:
+* [cloudflare/worker-template](https://github.com/cloudflare/worker-template)
+* [EverlastingBugstopper/worker-typescript-template](https://github.com/EverlastingBugstopper/worker-typescript-template)
+* [signalnerve/workers-graphql-server](https://github.com/signalnerve/workers-graphql-server)
+* [cloudflare/worker-sites-template](https://github.com/cloudflare/worker-sites-template)
+* [cloudflare/worker-template-router](https://github.com/cloudflare/worker-template-router)
+* [cloudflare/cobol-worker-template](https://github.com/cloudflare/cobol-worker-template)
+
+You can write additional documentation about your template that will be displayed in the Workers documentation, like this:
+
+[Template Gallery | Hello World Rust ](https://developers.cloudflare.com/workers/templates/pages/hello_world_rust)
+
+Such additional documentation lives in the [cloudflare/workers-docs](https://github.com/cloudflare/workers-docs/) repository.
+
+## Updating a Template
+If you spot an error in a template, feel free to make a PR against this repository!
+
+If you want to update the contents of a snippet, edit the TypeScript file (not the transpiled JavaScript version), and then run:
+```bash
+npm run transpile && npm run lint
+```
+This will transpile your TypeScript changes to the JavaScript version as well.
+
+## Creating a Snippet
+1. Clone this repository.
+2. Run `npm install` from the repo’s root directory to install development dependencies.
+3. Choose an `id` for your template. This should be a unique and descriptive “slug” like the other filenames in [`templates/meta_data`](./templates/meta_data).
+4. Create a new metadata file in [`templates/meta_data`](./templates/meta_data) with the name `your_template_id.toml`.
+5. Add your TypeScript template content in [`templates/typescript`](./templates/typescript) with the name `your_template_id.ts`.
+6. Run `npm run transpile && npm run lint` to generate the JavaScript version of your TypeScript file.
+7. Test your snippet in the [Cloudflare Workers Playground](https://cloudflareworkers.com/) or in a `wrangler` project.
+8. Make a PR to this repository containing three files:
+	* `templates/meta_data/your_template_id.toml`
+	* `templates/typescript/your_template_id.ts`
+	* `templates/javascript/your_template_id.js`
+
+## Creating a Boilerplate
+You can get started by cloning the [template creator](https://github.com/victoriabernard92/workers-template-creator) and following the instructions in the README. You can also start from scratch and add template placeholders to any `wrangler` project.
+
+### Testing Your Boilerplate
+A boilerplate must be capable of being installed with `wrangler generate`.
+
+Test using [`wrangler`](https://github.com/cloudflare/wrangler) to generate a new project from your boilerplate template:
+```
+wrangler generate your-template-id ./
+cd your-template-slug
+wrangler preview --watch
 ```
 
+Finally, publish your template in a public GitHub repo, and then test your boilerplate template by running:
+```
+wrangler generate https://github.com/<you>/<your-template-id>
+cd your-template-id
+wrangler preview --watch
+```
 
-# Summit
+### Submitting a Boilerplate to the Template Registry
+Create a metadata file for your template in `templates/meta_data`. Make sure to include a `repo` link to your boilerplate template’s GitHub repository.
 
-### **Required:**
-
-1. Submit a PR to this repo with the mandatory files:
-    - `id.toml` - a file in the [templates/meta_data](./templates/meta_data) folder. Make sure to include [mandatory fields](#mandatory-fields-for-all)
-    - `id.md`  - A markdown file to the docs repo in [templates/pages](https://github.com/cloudflare/workers-docs/tree/master/content/templates/pages) folder in the workers-docs
-    - `id.js` (Snippets only) - a javascript file following [Snippet Format Guidelines](#snippet-format) in the [templates/javascript](./templates/javascript) folder
-2. Double check all files use the same `id` in the filename
-### Boilerplate Only
-
-1. Host a public repo, and then test your project by running `wrangler generate https://github.com/<you>/<id>`.
-2. Hava a developer from Cloudflare's DX team review your code
-
-
-
-
+Then make a PR to this repo with your new metadata `toml` file.


### PR DESCRIPTION
The goals of this update are:
* Update documentation about Snippets to reflect that TypeScript files
  are the source of truth, and they must be transpiled.
* Generally, update anything that references JavaScript to reference
  TypeScript as well or instead.
* More clearly separate reference content (e.g. "these are the expected
  metadata fields in metadata.toml") from tutorial content (e.g. "clone
  X repo, make a PR to Y repo").
* Explain how boilerplate templates work more clearly.
* Polish up any typos, links, etc.

You can view a Markdown-rendered version of the final result here: https://github.com/cloudflare/template-registry/blob/c7abbfbe3c7433a506911cf8d195c2739f91a6fb/CONTRIBUTING.md