### PR TITLE
Fix Rust style guide heading

### DIFF
--- a/style/rust.md
+++ b/style/rust.md
@@ -1,4 +1,4 @@
-#Rust Style Guide
+# Rust Style Guide
 
 If you are using Wasm and write in Rust, your template should adhere to rustfmt and clippy.
 


### PR DESCRIPTION
Heading is broken:

<img width="798" alt="Screen Shot 2020-07-02 at 3 18 22 am" src="https://user-images.githubusercontent.com/418747/86272979-d22fc280-bc12-11ea-89a8-0c9540108562.png">



