### PR TITLE
Fix typo in meta_data/cache_api.toml

### DIFF
--- a/templates/meta_data/cache_api.toml
+++ b/templates/meta_data/cache_api.toml
@@ -2,5 +2,5 @@ id = "cache_api"
 weight = 1
 type = "snippet"
 title = "Cache API"
-description = "Cache using Cloudflare's [Cache API](/reference/apis/cache/). This example can cache POST requests as well as change what hostname to store a response in cache. Note the previewer is not avalible for using Cache API."
+description = "Cache using Cloudflare's [Cache API](/reference/apis/cache/). This example can cache POST requests as well as change what hostname to store a response in cache. Note the previewer is not available for using Cache API."
 tags = [ "Middleware" ]


### PR DESCRIPTION
"avalible" to "available"