### PR TITLE
Update cache_api.js to use Header.set instead of Header.append

### DIFF
--- a/templates/javascript/cache_api.js
+++ b/templates/javascript/cache_api.js
@@ -14,7 +14,7 @@ async function handleRequest(event) {
     response = new Response(response.body, response)
     // Cache API respects Cache-Control headers, so by setting max-age to 10
     // the response will only live in cache for max of 10 seconds
-    response.headers.append('Cache-Control', 'max-age=10')
+    response.headers.set('Cache-Control', 'max-age=10')
     // store the fetched response as cacheKey
     // use waitUntil so computational expensive tasks don't delay the response
     event.waitUntil(cache.put(cacheKey, response.clone()))


### PR DESCRIPTION
Hi,

I was having some issues with the Cache API not working as expected. I found that if the response already had a `Cache-Control` header, I needed to `set` instead of `append`. According to the [documentation for `set`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/set), set creates the header if it doesn't exist. I think it should be safe to change the `append` to `set` in the template.