### PR TITLE
Web Crypto API support in Sign and Verify Snippet

### DIFF
--- a/templates/javascript/signed_request.js
+++ b/templates/javascript/signed_request.js
@@ -35,6 +35,7 @@ async function signResponse(responseBody, response) {
     key,
     new TextEncoder().encode(responseBody),
   )
+  // Convert Uint8Array to Base64
   const sigHash = btoa(String.fromCharCode(...new Uint8Array(signature)))
   response.headers.set('signature', sigHash)
   return response
@@ -42,14 +43,12 @@ async function signResponse(responseBody, response) {
 async function verifySignature(request) {
   const signature = request.headers.get('signature') || ''
   const key = await importKey(SECRET)
-
+  // Convert Base64 to Uint8Array
+  const sigBuf = Uint8Array.from(atob(signature), c => c.charCodeAt(0))
   return await crypto.subtle.verify(
     'HMAC',
     key,
-    base64ToUint8Array(signature),
+    sigBuf,
     new TextEncoder().encode(await request.text()),
   )
-}
-function base64ToUint8Array(base64) {
-  return Uint8Array.from(atob(base64), c => c.charCodeAt(0))
 }

--- a/templates/javascript/signed_request.js
+++ b/templates/javascript/signed_request.js
@@ -1,17 +1,27 @@
 /**
- * GET  ->  provides base64 signature of responseBody as HTTP Header
- * POST ->  checks base64 signature provided as HTTP Header for the request text
+ * GET -> GET -> reply with an HTTP response header set to the signature for the text provided as a query string
+ * POST -> check the validity of base64 signature provided as an HTTP header for message in the HTTP body
  */
 const SECRET = 'SECRET_KEY'
-const responseBody = 'Hello worker!'
+
 addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request))
 })
+
 async function handleRequest(request) {
   if (request.method === 'GET') {
-    return await signResponse(responseBody, new Response(responseBody))
+    const url = new URL(request.url)
+    const msg = url.searchParams.get('msg') || ''
+    const signature = await signResponse(msg, SECRET)
+    let response = new Response(msg)
+    response.headers.set('signature', signature)
+
+    return response
   } else if (request.method === 'POST') {
-    const isSigValid = await verifySignature(request)
+    const message = await request.text()
+    const signature = request.headers.get('signature') || ''
+    const isSigValid = await verifySignature(message, signature, SECRET)
+
     return isSigValid
       ? new Response('Valid signature!')
       : new Response('Invalid signature!', { status: 400 })
@@ -19,6 +29,7 @@ async function handleRequest(request) {
     return new Response('Method not supported')
   }
 }
+
 async function importKey(secret) {
   return await crypto.subtle.importKey(
     'raw',
@@ -28,27 +39,29 @@ async function importKey(secret) {
     ['sign', 'verify'],
   )
 }
-async function signResponse(responseBody, response) {
-  const key = await importKey(SECRET)
+
+async function signResponse(message, secret) {
+  const key = await importKey(secret)
   const signature = await crypto.subtle.sign(
     'HMAC',
     key,
-    new TextEncoder().encode(responseBody),
+    new TextEncoder().encode(message),
   )
-  // Convert Uint8Array to Base64
-  const sigHash = btoa(String.fromCharCode(...new Uint8Array(signature)))
-  response.headers.set('signature', sigHash)
-  return response
+
+  // Convert ArrayBuffer to Base64
+  return btoa(String.fromCharCode(...new Uint8Array(signature)))
 }
-async function verifySignature(request) {
-  const signature = request.headers.get('signature') || ''
-  const key = await importKey(SECRET)
+
+async function verifySignature(message, signature, secret) {
+  const key = await importKey(secret)
+
   // Convert Base64 to Uint8Array
   const sigBuf = Uint8Array.from(atob(signature), c => c.charCodeAt(0))
+
   return await crypto.subtle.verify(
     'HMAC',
     key,
     sigBuf,
-    new TextEncoder().encode(await request.text()),
+    new TextEncoder().encode(message),
   )
 }

--- a/templates/javascript/signed_request.js
+++ b/templates/javascript/signed_request.js
@@ -1,35 +1,55 @@
-// NOTE Requires ESM through webpack project type
-const crypto = require('crypto')
+/**
+ * GET  ->  provides base64 signature of responseBody as HTTP Header
+ * POST ->  checks base64 signature provided as HTTP Header for the request text
+ */
 const SECRET = 'SECRET_KEY'
-async function handleRequest(request) {
-  let signed = await checkSignature(request)
-  if (signed) {
-    let responseBody = 'Hello worker!'
-    return await signResponse(responseBody, new Response(responseBody))
-  } else {
-    return new Response('Request not signed', { status: 400 })
-  }
-}
+const responseBody = 'Hello worker!'
 addEventListener('fetch', event => {
-  console.log(createHexSignature('asd'))
   event.respondWith(handleRequest(event.request))
 })
-async function createHexSignature(requestBody) {
-  let hmac = crypto.createHmac('sha256', SECRET)
-  hmac.update(requestBody)
-  return hmac.digest('hex')
+async function handleRequest(request) {
+  if (request.method === 'GET') {
+    return await signResponse(responseBody, new Response(responseBody))
+  } else if (request.method === 'POST') {
+    const isSigValid = await verifySignature(request)
+    return isSigValid
+      ? new Response('Valid signature!')
+      : new Response('Invalid signature!', { status: 400 })
+  } else {
+    return new Response('Method not supported')
+  }
 }
-async function checkSignature(request) {
-  // hash request with secret key
-  let expectedSignature = await createHexSignature(await request.text())
-  let actualSignature = await request.headers.get('signature')
-  // check that hash matches signature
-  return expectedSignature === actualSignature
+async function importKey(secret) {
+  return await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  )
 }
 async function signResponse(responseBody, response) {
-  // create signature
-  const signature = await createHexSignature(responseBody)
-  response.headers.set('signature', signature)
-  //add header with signature
+  const key = await importKey(SECRET)
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(responseBody),
+  )
+  const sigHash = btoa(String.fromCharCode(...new Uint8Array(signature)))
+  response.headers.set('signature', sigHash)
   return response
+}
+async function verifySignature(request) {
+  const signature = request.headers.get('signature') || ''
+  const key = await importKey(SECRET)
+
+  return await crypto.subtle.verify(
+    'HMAC',
+    key,
+    base64ToUint8Array(signature),
+    new TextEncoder().encode(await request.text()),
+  )
+}
+function base64ToUint8Array(base64) {
+  return Uint8Array.from(atob(base64), c => c.charCodeAt(0))
 }


### PR DESCRIPTION
Update the signed_requested.js snippet that demonstrates signing and verifying HMAC tokens to use the Web Crypto API instead of `require("crypto")`.

Web Crypto is natively supported by the Workers Runtime and allows you to sign and verify with plain JavaScript workers instead of needing to use webpack.

Additionally, the developer documentation on the [Web Crypto API for Workers](https://developers.cloudflare.com/workers/reference/apis/web-crypto) mentions using the API for signing and verifying:

> This API is commonly used for [signing requests](https://developers.cloudflare.com/workers/reference/write-workers/best-practices/signing-requests)

 But that link just redirects to the home page for the Cloudflare Workers documentation.  This snippet could provide a landing spot for that link for those interested in learning more.